### PR TITLE
Add some improvement to script and support version 68.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ crackb0x:SketchCrapp duraki$ ./sketchcrapp.sh -h
 
 Usage:
 ./sketchcrapp [-h] [-a] <applicationPath>
-Supported versions: v63.1, v64.0, v65.1, v66.1, v67.1, v67.2 v68
+Supported versions: v63.1, v64.0, v65.1, v66.1, v67.1, v67.2, v68, v68.1
 ```
 
 ```


### PR DESCRIPTION
Implement #16 and #17 

Script now check both CFBundleShortVersionString and hash, the patch process only execute when both version values are equal.
Version 68.1 is now supported.
Although I've test most scenarios but may have some I didn't cover. please tell me I'll improve it.
