### PR TITLE
Add functionality to make debug message more clear and informative. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,24 +48,24 @@ crackb0x:SketchCrapp duraki$ ./sketchcrapp.sh
 
 SketchCrapp is finding application bundle path ...
 [+] Selected Sketch.app path is </Applications> (auto-detected) ... OK
-[+] Selected Sketch.app version is 68 ... SketchCrapp starting ... OK
-[+] Patching offsets for 68 ...
-[+] Patching address at offset: 0x54d2af with value: \00
+[+] Selected Sketch.app version is 68.1 ... SketchCrapp starting ... OK
+[+] Patching offsets for 68.1 ...
+[+] Patching address at offset: 0x54d34f with value: \00
 1+0 records in
 1+0 records out
-1 bytes transferred in 0.000026 secs (38480 bytes/sec)
-[+] Patching address at offset: 0x54d2b2 with value: \00
+1 bytes transferred in 0.000028 secs (35545 bytes/sec)
+[+] Patching address at offset: 0x54d352 with value: \00
 1+0 records in
 1+0 records out
-1 bytes transferred in 0.000029 secs (34664 bytes/sec)
-[+] Patching address at offset: 0x54bf8a with value: \00\00
+1 bytes transferred in 0.000018 secs (55188 bytes/sec)
+[+] Patching address at offset: 0x54c02a with value: \00\00
 2+0 records in
 2+0 records out
-2 bytes transferred in 0.000029 secs (68759 bytes/sec)
-[+] Patching address at offset: 0x54c0c9 with value: \165
+2 bytes transferred in 0.000023 secs (86480 bytes/sec)
+[+] Patching address at offset: 0x54c169 with value: \165
 1+0 records in
 1+0 records out
-1 bytes transferred in 0.000021 secs (47663 bytes/sec)
+1 bytes transferred in 0.001926 secs (519 bytes/sec)
 security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.
 [+] Generating self-signed certificate ...
 Generating a 521 bit EC private key

--- a/sketchcrapp.sh
+++ b/sketchcrapp.sh
@@ -101,8 +101,7 @@ banner() {
     /___/_/\_\\__/\__/\__/_//_/\__/_/  \_,_/ .__/ .__/
                                           /_/  /_/
          Sketch.App Patch Tool (https://github.com/duraki/SketchCrapp)
-         by @elijahtsai & @duraki
-
+         by @duraki & @elijahtsai
 
 EOF
 }
@@ -111,8 +110,8 @@ EOF
 usage() {
   echo "Usage:"
   echo "./sketchcrapp [-h] [-a] <applicationPath>"
-  echo "Supported versions: v63.1, v64.0, v65.1, v66.1, v67.1, v67.2,\
- v68 v68.1"
+  echo "Supported versions: v63.1, v64.0, v65.1, v66.1, v67.1, v67.2, \
+v68, v68.1"
   exit 0;
 }
 
@@ -171,6 +170,43 @@ signApplication() {
   codesign --deep --force -s "sketchcrapp" "$appPath"
 }
 
+#Get binary hash from CFBundleShortVersionString
+# - Parameters:
+#     - First: The application bundle CFBundleShortVersionString.
+getHashFromVersionString() {
+  
+  local bundleVersionString="$1"
+
+  case "$bundleVersionString" in
+    "63.1")
+      echo "$exe_hash_631"
+      ;;
+    "64")
+      echo "$exe_hash_640"
+      ;;
+    "65.1")
+      echo "$exe_hash_651"
+      ;;
+    "66.1")
+      echo "$exe_hash_661"
+      ;;
+    "67.1")
+      echo "$exe_hash_671"
+      ;;
+    "67.2")
+      echo "$exe_hash_672"
+      ;;
+    "68")
+      echo "$exe_hash_680"
+      ;;
+    "68.1")
+      echo "$exe_hash_681"
+      ;;
+    *)
+      echo "Input version string invaild, cannot lookup correct hash value."
+  esac
+}
+
 # Verify the application by using hash value.
 # - Parameters:
 #     - First: The application bundle path.
@@ -180,7 +216,7 @@ analysisApplication() {
     
   if ! [ -d "$appPath" ]; then
     echo "[-] The path of application $appPath is incorrect."
-    echo "[ERR] Couldn't find: $appPath"
+    echo "[ERR] Couldn't find application at $appPath"
     exit 1
   fi
 
@@ -189,7 +225,8 @@ analysisApplication() {
 
   if ! [ -f "$execPath" ]; then
     echo "[-] Executable file does not exists under the given application folder."
-    echo "[ERR] Couldn't find: $execPath"
+    echo "[ERR] Couldn't find executable file at $execPath"
+    echo "[INFO] Please make sure you pass clean app to script."
     exit 1
   fi
 
@@ -198,7 +235,8 @@ analysisApplication() {
 
   if ! [ -f "$infoPath.plist" ]; then
     echo "[-] Info file does not exists under the given application folder."
-    echo "[ERR] Couldn't find: $infoPath.plist"
+    echo "[ERR] Couldn't find Info.plist at $infoPath.plist"
+    echo "[INFO] Please make sure you pass clean app to script."
     exit 1
   fi
 
@@ -207,8 +245,13 @@ analysisApplication() {
 
   if [ -z "$bundleVersionString" ]; then
     echo "[ERR] Couldn't find value of CFBundleShortVersionString"
+    echo "[INFO] Please make sure you pass clean app to script."
     exit 1
   fi
+
+  # Get the hash of application executable
+  local appSHA1="$(shasum -a 1 "$execPath" | cut -f 1 -d ' ')"
+  
   
   local ticket=0
 
@@ -219,9 +262,9 @@ analysisApplication() {
     fi
   done
 
-  if ! [ "$ticket" -eq 1 ]; then
+  if [ "$ticket" -eq 0 ]; then
     echo "[+] Copy the details below and open a new issue on GitHub repository: \
-    https://github.com/duraki/SketchCrapp"
+https://github.com/duraki/SketchCrapp"
     echo "+==================================================================="
     echo "+ Issue details ‹s:sketchcrapp›"
     echo "+ Application Path  : $appPath"
@@ -233,9 +276,6 @@ analysisApplication() {
     exit 1
   fi
 
-  # Get the hash of application executable
-  local appSHA1="$(shasum -a 1 "$execPath" | cut -f 1 -d ' ')"
-  
   local testBundleVersionString=""
 
   case "$appSHA1" in
@@ -265,12 +305,13 @@ analysisApplication() {
       ;;
     *)
       echo "[+] Copy the details below and open a new issue on GitHub repository: \
-      https://github.com/duraki/SketchCrapp"
+https://github.com/duraki/SketchCrapp"
       echo "+==================================================================="
       echo "+ Issue details ‹s:sketchcrapp›"
       echo "+ Application Path  : $appPath"
       echo "+ Application Binary: $execPath"
       echo "+ Passed version    : $bundleVersionString"
+      echo "+ Correct hash      : $(getHashFromVersionString "$bundleVersionString")"
       echo "+ Binary SHA1       : $appSHA1"
       echo "+ Error             : Can’t look up version from hash."
       echo "+==================================================================="
@@ -345,7 +386,7 @@ engin() {
     *)
       echo "Something went wrong, this line should never execute."
       echo "[+] Copy the details below and open a new issue on GitHub repository: \
-      https://github.com/duraki/SketchCrapp"
+https://github.com/duraki/SketchCrapp"
       echo "+==================================================================="
       echo "+ Issue details ‹s:sketchcrapp›"
       echo "+ Application Path  : $appPath"
@@ -354,6 +395,7 @@ engin() {
       echo "+ Binary SHA1       : $appSHA1"
       echo "+ Error             : patcherr››"
       echo "+==================================================================="
+      exit 1
   esac
   # CodeSigning area.
   # Check if sketchcrapp certificate already exist.
@@ -424,11 +466,12 @@ while getopts "ha:" argv; do
         analysisApplication "$appPath"
       else
         echo "[ERR] Given directory is either invaild or not exist."
+        exit 1
       fi
       ;;
     *)
       echo "Use -h for more information."
-      exit 0;
+      exit 0
       ;;
   esac
 done


### PR DESCRIPTION
**I highly suggest developers who forked our project previously to make a pull request in order to update this big change and improvement.**

I change the code structure again in order to let debug message more clear and more suitable for an unknown problem, so can help us investigating easier. Second,  to let future versions easier to add and manage. 

Close #17 I try to avoid to calculate version, reason one is I don't know how to do it and I think this is not a safe way to do if anyone knows how to do and safety is considered I'm happy to implement. reason two is there are too many reasons will trigger this error like version too low we are too lazy to patch or version too high we haven't catch yet or the version we skip like v65 or v66. So I decided to let user read README again. 🤪 Don't blame me on this. Read the file CAREFULLY. 

Close #16 I had implemented.

