### PR TITLE
Change patch cycle count. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Checking if Sketch.app exist in /tmp ... Not exist. Continuous.
 
 [+] SketchCrapp (A Sketch.app cracking tool)
 [+] https://github.com/duraki/SketchCrapp [by @duraki & @elijahtsai]
-[+] SketchCrapp last published date: 2020-12-27 serial 001
+[+] SketchCrapp last published date: 2020-12-28 serial 001
 ```
 
 ## Issues

--- a/sketchcrapp.sh
+++ b/sketchcrapp.sh
@@ -179,7 +179,7 @@ EOF
 # Last function to run before exit.
 finally() {
   local status="$1"
-  echo "[+] SketchCrapp last published date: 2020-12-27 serial 001"
+  echo "[+] SketchCrapp last published date: 2020-12-28 serial 001"
   exit $status
 }
 

--- a/sketchcrapp.sh
+++ b/sketchcrapp.sh
@@ -528,7 +528,7 @@ patch() {
 
   local execPath=${2}
 
-  for i in {0..11}; do
+  for i in {0..5}; do
     echo "[+] Patching address at offset: ${addressArray[$i]} \
 with value: ${value_param[$i]}"
     printf "${value_param[$i]}" | dd seek="$((${addressArray[$i]}))" conv=notrunc bs=1 of="$execPath"


### PR DESCRIPTION
Since there has Rosetta 2 then we decided to only focus in x86-64 architecture, so in the patch cycle would only patch the x86 side of address but will retain the m1 side of address to people who want to take a look and improvement