### PR TITLE
Fix OpenSSL error on macOS Ventura 13.4.1

### DIFF
--- a/sketchcrapp.sh
+++ b/sketchcrapp.sh
@@ -356,7 +356,7 @@ genSelfSignCert() {
    -keyform pem -keyout pk.pem \
    -outform pem -out crt.pem
   echo "[+] Creating pkcs package..."
-  openssl pkcs12 -export -out pkcs.p12 -in crt.pem -inkey pk.pem \
+  openssl pkcs12 -export -legacy -out pkcs.p12 -in crt.pem -inkey pk.pem \
   -name "sketchcrapp" -nodes -passout pass:1234
 }
 


### PR DESCRIPTION
I tried patching Sketch on Ventura, but failed to do because of the following error:

```txt
// ...
[+] Creating pkcs package...
Warning: output encryption option -nodes ignored with -export
[+] Importing private key and self-signed certificate
security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?) // <<<<<
[+] Signing the patched *.app bundle. This may require root privilege.
[+] If asked, enter your login password. Choose "Always Allow" to not be asked again.
error: The specified item could not be found in the keychain.
```

As far as I know OpenSSL 3.x changed its default algorithm in pkcs12. Which is not compatible with embedded Security frameworks in macOS/iOS so that's the reason why importing to keychain fails.

Adding `-legacy` option to openssl export command seems to solve the issue.