### PR TITLE
Fix openssl v2 wrong args error

### DIFF
--- a/sketchcrapp.sh
+++ b/sketchcrapp.sh
@@ -356,7 +356,9 @@ genSelfSignCert() {
    -keyform pem -keyout pk.pem \
    -outform pem -out crt.pem
   echo "[+] Creating pkcs package..."
-  openssl pkcs12 -export -legacy -out pkcs.p12 -in crt.pem -inkey pk.pem \
+  opensslMajorVersion=$(openssl version | cut -d' ' -f2 | cut -d'.' -f1)
+  opensslLegacyFlag=$([ "$opensslMajorVersion" -gt 2 ] && echo "-legacy")
+  openssl pkcs12 -export $opensslLegacy -out pkcs.p12 -in crt.pem -inkey pk.pem \
   -name "sketchcrapp" -nodes -passout pass:1234
 }
 


### PR DESCRIPTION
It turned out that my previous fix for openssl (#98) introduced an error for users who are still on openssl v2 where `-legacy` option is still unknown. This PR tries to make the script work with both v2 and v3 versions of openssl.

I discovered that my previous OpenSSL fix (#98) caused issues for users who are still on version 2. This PR aims to enhance the script to support both version 2 and version 3 of OpenSSL by using the `-legacy` option conditionally.